### PR TITLE
Allow hyphens in Bedrock tool names

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3625,7 +3625,7 @@ def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
         """
         Bedrock tool names only supports alpha-numeric characters and underscores
         """
-        if char.isalnum() or char == "_":
+        if char.isalnum() or char == "_" or char == "-":
             return char
         return "_"
 


### PR DESCRIPTION
Add hyphen character to allowed characters in make_valid_bedrock_tool_name function alongside existing alphanumeric and underscore characters.

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


